### PR TITLE
MOB-3917 Scrolling issue can be fixed by hiding the weekly calendar v…

### DIFF
--- a/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
+++ b/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
@@ -527,7 +527,7 @@ public class MonthWeekMaterialCalendarView extends FrameLayout implements SlideM
 
             @Override
             public void onAnimationEnd(Animator animator) {
-//                mCalendarViewWeek.setVisibility(VISIBLE);
+//                mCalendarViewWeek.setVisibility(VISIBLE); //Don't show the calendar weekly view otherwise the calendar won't scroll to the selected date
                 mCalendarViewMonth.clearAnimation();
                 //动画播放完毕说明已经滚动到了顶部
                 animatStart = false;

--- a/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
+++ b/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
@@ -527,7 +527,7 @@ public class MonthWeekMaterialCalendarView extends FrameLayout implements SlideM
 
             @Override
             public void onAnimationEnd(Animator animator) {
-                mCalendarViewWeek.setVisibility(VISIBLE);
+//                mCalendarViewWeek.setVisibility(VISIBLE);
                 mCalendarViewMonth.clearAnimation();
                 //动画播放完毕说明已经滚动到了顶部
                 animatStart = false;


### PR DESCRIPTION
This issue depends on this fix
https://affinitylive.jira.com/browse/MOB-3917

Scrolling issue fixed when weekly calendar view is hidden on animation ends.

Video of the original issue:
[calendar_scrolling_issue.webm.zip](https://github.com/Accelo/monthweekmaterialcalendarview/files/5126838/calendar_scrolling_issue.webm.zip)




