### PR TITLE
Timesheet mob 3917 weekly calendar scrolling issue

### DIFF
--- a/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
+++ b/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
@@ -527,7 +527,7 @@ public class MonthWeekMaterialCalendarView extends FrameLayout implements SlideM
 
             @Override
             public void onAnimationEnd(Animator animator) {
-//                mCalendarViewWeek.setVisibility(VISIBLE); //Don't show the calendar weekly view otherwise the calendar won't scroll to the selected date
+                mCalendarViewWeek.setVisibility(VISIBLE);
                 mCalendarViewMonth.clearAnimation();
                 //动画播放完毕说明已经滚动到了顶部
                 animatStart = false;

--- a/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
+++ b/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
@@ -527,7 +527,7 @@ public class MonthWeekMaterialCalendarView extends FrameLayout implements SlideM
 
             @Override
             public void onAnimationEnd(Animator animator) {
-//                mCalendarViewWeek.setVisibility(VISIBLE);
+//                mCalendarViewWeek.setVisibility(VISIBLE); //Don't show the calendar weekly view otherwise the calendar won't scroll to the selected date
                 mCalendarViewMonth.clearAnimation();
                 //动画播放完毕说明已经滚动到了顶部
                 animatStart = false;

--- a/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
+++ b/calendarLibrary/src/main/java/com/amy/monthweek/materialcalendarview/MonthWeekMaterialCalendarView.java
@@ -527,7 +527,7 @@ public class MonthWeekMaterialCalendarView extends FrameLayout implements SlideM
 
             @Override
             public void onAnimationEnd(Animator animator) {
-                mCalendarViewWeek.setVisibility(VISIBLE);
+//                mCalendarViewWeek.setVisibility(VISIBLE);
                 mCalendarViewMonth.clearAnimation();
                 //动画播放完毕说明已经滚动到了顶部
                 animatStart = false;

--- a/calendarLibrary/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
+++ b/calendarLibrary/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
@@ -249,11 +249,11 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
         }
 
         if (min == null) {
-            min = CalendarDay.from(today.getYear() - 200, today.getMonth(), today.getDay());
+            min = CalendarDay.from(today.getYear() - 40, today.getMonth(), today.getDay());
         }
 
         if (max == null) {
-            max = CalendarDay.from(today.getYear() + 200, today.getMonth(), today.getDay());
+            max = CalendarDay.from(today.getYear() + 40, today.getMonth(), today.getDay());
         }
 
         rangeIndex = createRangeIndex(min, max);


### PR DESCRIPTION
When Calendar view minimum set to year 1820, weekly view pager is buggy, minimum and maximum date range reduced and issue disappeared

Video of original issue:
[monthweekmaterialcalendarview.zip](https://github.com/Accelo/monthweekmaterialcalendarview/files/5134442/monthweekmaterialcalendarview.zip)

Link to Jira Issue
https://affinitylive.jira.com/browse/MOB-3917
